### PR TITLE
Add difficulty + overall parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,10 +89,23 @@ async function handleRequest(request) {
   }
 
   // create issue
-  const { course, user, review, reference } = json.details
+  const { course, user, review, reference, difficulty, overall } = json.details
+
 
   const title = `New review for ${course} by ${user}`
-  const body = `> ${review}\n> \n> [${user}](${reference})`
+  let body = `> ${review}\n>\n`
+
+  const parsedDifficulty = parseFloat(difficulty)
+  if (!isNaN(parsedDifficulty)) {
+    body += `> Difficulty: ${parsedDifficulty}/5\n`
+  }
+
+  const parsedOverall = parseFloat(overall)
+  if (!isNaN(parsedOverall)) {
+    body += `> Overall: ${parsedOverall}/5\n`
+  }
+
+  body += `> <cite><a href="${reference}">${user}</a>, ${new Date().toDateString().split(" ").slice(1).join(" ")}</cite>`
 
   const response = await octokit.rest.issues.create({
     owner: OWNER,


### PR DESCRIPTION
This PR passes the difficulty + overall course quality parameters to the GitHub issues creation API. 

Also fixes the user reference - we want to use `<cite>` and not just a link. As well, added the current date as per ubccsss/ubccsss.org#212.

I clamp this to 1-5 and check for the JSON type. This should already be safely ensured in the UI, but if someone hits our worker with a script somehow having already passed the Captcha I figured we may as well add some verification to be safe.