### PR TITLE
Create PRs in reverse chronological order

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,8 +174,10 @@ async function handleRequest(request) {
 
 			// if the file exists, we will append the new review to the existing reviews
 			// otherwise, we will create a new file with the new review
-			const existingReviewsContent = Buffer.from(existingReviews.data.content, 'base64').toString()
-			yaml = existingReviewsContent + yaml
+			const existingReviewsContent = Buffer.from(existingReviews.data.content, 'base64')
+				.toString()
+				.replace('reviews:\n', '')
+			yaml = 'reviews:\n' + yaml + existingReviewsContent
 		} catch (e) {
 			// if the file doesn't exist, we will create a new file with the new review
 			yaml = 'reviews:\n' + yaml
@@ -216,7 +218,7 @@ async function handleRequest(request) {
 			repo: REPO,
 			pull_number: newPR.data.number,
 			reviewers: USERS.split(','),
-			team_reviewers: TEAMS.split(',')
+			team_reviewers: TEAMS.split(','),
 		})
 
 		// return the url of the new PR

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,7 @@ type = "webpack"
 
 account_id = "f8ffb577efdf82b0303f86d7b4ca94a5"
 workers_dev = true
+node_compat = true
 
 compatibility_date = "2022-09-07"
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,6 @@ type = "webpack"
 
 account_id = "f8ffb577efdf82b0303f86d7b4ca94a5"
 workers_dev = true
-node_compat = true
 
 compatibility_date = "2022-09-07"
 


### PR DESCRIPTION
As per [this discussion](https://ubccsss.slack.com/archives/C03G2GP5UUX/p1668706157310809), add new PRs to the top of the YAML file instead of at the bottom.

Also added `node_compat=true` to `wrangler.toml` because `npx wrangler publish` was complaining.